### PR TITLE
Pivot from Elastic Beanstalk to AWS App Runner

### DIFF
--- a/.ebignore
+++ b/.ebignore
@@ -1,9 +1,0 @@
-.ebignore
-.git
-.gitignore
-.gcloudignore
-app.yaml
-appengine_config.py
-.idea/
-__pycache__/
-*.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,17 @@
 # AlexAbraham.dev
 
-Personal portfolio website. Flask app deployed on AWS Elastic Beanstalk.
+Personal portfolio website. Flask app deployed on AWS App Runner.
 
 ## Stack
-- Python 3.13 / Flask
-- AWS Elastic Beanstalk (hosting)
-- AWS SES (contact form email, authenticated via IAM role — no API keys)
+- Python 3.11 / Flask
+- AWS App Runner (source-based deploy from GitHub, auto-deploys on push to `master`)
+- AWS SES (contact form email, authenticated via IAM instance role — no API keys)
 
 ## Project Structure
 - `main.py` — Flask app (routes: `GET /`, `POST /send_email`)
 - `templates/` — Jinja2 main template + HTML snippets for work experience and education
 - `static/` — CSS, JS, images, PDFs, skill logos
-- `Procfile` — gunicorn startup command for Elastic Beanstalk
+- `apprunner.yaml` — App Runner build + run config
 
 ## Local Development
 ```bash
@@ -20,9 +20,7 @@ python main.py
 Runs at http://127.0.0.1:8080
 
 ## Deploy
-```bash
-eb deploy
-```
+Push to `master`. App Runner auto-deploys.
 
 ## Tests
 ```bash

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: gunicorn --bind 0.0.0.0:8080 --workers 4 main:app

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # AlexAbraham.dev
-Personal Website powered by AWS
-
-## Prerequisites
-- AWS CLI configured (`aws configure`)
-- EB CLI installed (`pip install awsebcli`)
-- EB environment initialized (`eb init` — one-time setup, see below)
+Personal Website powered by AWS App Runner
 
 ## Local Development
 ```bash
@@ -13,9 +8,7 @@ python main.py
 Runs at http://127.0.0.1:8080
 
 ## Deploy
-```bash
-eb deploy
-```
+Push to `master`. App Runner is wired to this repo and auto-deploys on push.
 
 ## One-Time AWS Setup
 
@@ -27,11 +20,22 @@ aws ses verify-domain-identity --domain alexabraham.dev --region us-east-1
 Add the returned TXT records to DNS for each domain.
 
 ### 2. Request SES production access
-Go to AWS console → SES → Account dashboard → "Request production access".
-This removes sandbox restrictions so email can be sent to unverified addresses.
+AWS console → SES → Account dashboard → "Request production access".
+Removes sandbox restrictions so email can be sent to unverified recipients.
 
-### 3. Create IAM instance profile for Elastic Beanstalk
-Attach a policy allowing `ses:SendEmail` on both SES identities:
+### 3. Create App Runner instance role
+This role is assumed by the running container — App Runner's equivalent of an EC2 instance profile.
+
+Trust policy:
+```json
+{
+  "Effect": "Allow",
+  "Principal": { "Service": "tasks.apprunner.amazonaws.com" },
+  "Action": "sts:AssumeRole"
+}
+```
+
+Inline permissions policy (`ses:SendEmail` on both domains):
 ```json
 {
   "Effect": "Allow",
@@ -43,8 +47,43 @@ Attach a policy allowing `ses:SendEmail` on both SES identities:
 }
 ```
 
-### 4. Initialize Elastic Beanstalk
+### 4. Create GitHub connection
+AWS console → App Runner → Connections → Create → GitHub → authorize the `AlexAbraham1` account.
+
+### 5. Create the App Runner service
 ```bash
-eb init alexabraham-dev --platform "Python 3.13" --region us-east-1
-eb create alexabraham-prod
+aws apprunner create-service \
+  --service-name alexabraham-prod \
+  --source-configuration '{
+    "AuthenticationConfiguration": { "ConnectionArn": "<connection-arn>" },
+    "AutoDeploymentsEnabled": true,
+    "CodeRepository": {
+      "RepositoryUrl": "https://github.com/AlexAbraham1/AlexAbraham.dev",
+      "SourceCodeVersion": { "Type": "BRANCH", "Value": "master" },
+      "CodeConfiguration": { "ConfigurationSource": "REPOSITORY" }
+    }
+  }' \
+  --instance-configuration '{
+    "Cpu": "256", "Memory": "512",
+    "InstanceRoleArn": "arn:aws:iam::<acct>:role/AppRunnerInstanceRole-alexabraham"
+  }' \
+  --region us-east-1
 ```
+
+### 6. Pin auto-scaling to a single warm instance (avoids cold starts)
+```bash
+aws apprunner create-auto-scaling-configuration \
+  --auto-scaling-configuration-name alexabraham-min \
+  --min-size 1 --max-size 1 --max-concurrency 100 --region us-east-1
+aws apprunner update-service --service-arn <svc-arn> \
+  --auto-scaling-configuration-arn <asc-arn> --region us-east-1
+```
+
+### 7. Associate custom domains
+```bash
+aws apprunner associate-custom-domain --service-arn <svc-arn> \
+  --domain-name alexabraham.net --enable-www-subdomain --region us-east-1
+aws apprunner associate-custom-domain --service-arn <svc-arn> \
+  --domain-name alexabraham.dev --enable-www-subdomain --region us-east-1
+```
+Add the returned cert-validation CNAMEs and target CNAMEs at your DNS provider. Apex records require ALIAS / ANAME / CNAME-flattening (Route 53 ALIAS, Cloudflare CNAME-flattening, etc.).

--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -1,0 +1,15 @@
+version: 1.0
+runtime: python311
+build:
+  commands:
+    build:
+      - pip install --no-cache-dir -r requirements.txt
+run:
+  runtime-version: 3.11
+  command: gunicorn --bind 0.0.0.0:8080 --workers 2 --threads 4 main:app
+  network:
+    port: 8080
+    env: PORT
+  env:
+    - name: FLASK_ENV
+      value: production


### PR DESCRIPTION
## Summary

PR #10 (GCP → EB) merged but was never deployed — GCP App Engine is still serving live traffic. This PR pivots `master` to target **AWS App Runner** instead, so the actual production cutover can go GCP → App Runner directly with no EB stand-up/tear-down in between.

- **Add `apprunner.yaml`** — source-based deployment via App Runner's managed Python 3.11 runtime; no Docker, no ECR
- **Right-size gunicorn** — `--workers 2 --threads 4` instead of `--workers 4` (4 prefork workers would memory-thrash on the 0.5 GB instance)
- **Delete `Procfile` and `.ebignore`** (EB-specific)
- **Update `README.md` and `CLAUDE.md`** with App Runner one-time setup and `git push`-to-deploy workflow
- **No code changes** — `main.py`, `requirements.txt`, `main_test.py` untouched. boto3 still discovers SES credentials via the App Runner instance role (same default credential chain as EC2).

### Why App Runner over EB
- **Cost**: ~$4–5/mo (App Runner min=1 / 0.25 vCPU / 0.5 GB) vs ~$8/mo (EB t3.micro + EBS)
- **HTTPS**: included free; no need for CloudFront in front of single-instance EB
- **Deploy UX**: auto-deploys on push to `master` once the GitHub connection is wired up

## Test plan

- [ ] Complete one-time AWS setup per README (SES verify → instance role → GitHub connection → `create-service` → auto-scaling pin → custom-domain associate)
- [ ] Hit App Runner default URL (`https://<svc>.awsapprunner.com/`) — portfolio renders, static assets serve, contact form delivers email to `alexgabraham1@gmail.com`
- [ ] Lower TTLs on GCP App Engine DNS records to 60s
- [ ] Cut DNS for `alexabraham.net` and `alexabraham.dev` from GCP App Engine to App Runner CNAME targets (apex needs ALIAS / ANAME / CNAME-flattening)
- [ ] Soak 24–48 hours, then decommission GCP App Engine + Firestore

https://claude.ai/code/session_016bNnP9qc8xaquqQmJQTgEk

---
_Generated by [Claude Code](https://claude.ai/code/session_016bNnP9qc8xaquqQmJQTgEk)_